### PR TITLE
Unquantize Points during presimplify

### DIFF
--- a/src/presimplify.js
+++ b/src/presimplify.js
@@ -64,10 +64,28 @@ export default function(topology, weight) {
     return arc;
   });
 
+  for (const key in topology.objects) {
+    topology.objects[key] = unquantizeGeometry(topology.objects[key]);
+  }
+
   function update(triangle) {
     heap.remove(triangle);
     triangle[1][2] = weight(triangle);
     heap.push(triangle);
+  }
+
+  function unquantizeGeometry(input) {
+    var output;
+    switch (input.type) {
+      case "GeometryCollection": output = {type: "GeometryCollection", geometries: input.geometries.map(unquantizeGeometry)}; break;
+      case "Point": output = {type: "Point", coordinates: point(input.coordinates)}; break;
+      case "MultiPoint": output = {type: "MultiPoint", coordinates: input.coordinates.map(point)}; break;
+      default: return input;
+    }
+    if (input.id != null) output.id = input.id;
+    if (input.bbox != null) output.bbox = input.bbox;
+    if (input.properties != null) output.properties = input.properties;
+    return output;
   }
 
   return {


### PR DESCRIPTION
Simplifying a topology requires the removal of the transform (if any).\
This is done it the presimplify() function.

presimplify() only does that on arcs, not points.
If the topology is quantized again later, points will be quantized twice, yielding invalid values.

With this commit, presimplify() also remove the transform of Point & MultiPoint objects.

The code for this fix is heavily inspired by <https://github.com/topojson/topojson-client/blob/71e5bd6428fd8b7a40fa980d2ef7862140851f03/src/quantize.js>.

For example, here is a topology corresponding to Washington DC, which has been quantized with `q=1e4`:

```json
{
  "type": "Topology",
  "objects": {
    "subunits": {
      "type": "GeometryCollection",
      "geometries": [
        {
          "type": "Polygon",
          "arcs": [[0]],
          "properties": {
            "name": "District of Columbia"
          }
        }
      ]
    },
    "places": {
      "type": "GeometryCollection",
      "geometries": [
        {
          "type": "Point",
          "coordinates": [5151, 5105],
          "properties": {
            "name": "Washington, D.C."
          }
        }
      ]
    }
  },
  "arcs": [
    [
      [4601, 0],
      [-211, 886],
      [279, 870],
      [174, 437],
      [91, 471],
      [-173, 361],
      [-302, 586],
      [-482, 374],
      [-644, 438],
      [-497, 557],
      [-392, 148],
      [-759, 76],
      [-614, 248],
      [-1071, 1337],
      [1933, 1678],
      [1765, 1532],
      [2918, -2470],
      [3383, -2864],
      [-2801, -2421],
      [-2597, -2244]
    ]
  ],
  "bbox": [
    -77.11978099719528,
    38.80276753027573,
    -76.90931454193253,
    38.99613558029279
  ],
  "transform": {
    "scale": [
      0.00002104875040131482,
      0.00001933873887559323
    ],
    "translate": [
      -77.11978099719528,
      38.80276753027573
    ]
  }
}
```

The location for the label is quantized:
```json
"coordinates": [5151, 5105]
```

Running `toposimplify -P 0.5 dc.json` was causing the coordinates of the label to be quantized twice:

```json
"coordinates": [248381480, 261971438]
```